### PR TITLE
Add `deployed_contracts` and `replaced_classes` to `StateDiff`

### DIFF
--- a/p2p/proto/state.proto
+++ b/p2p/proto/state.proto
@@ -18,8 +18,15 @@ message StateDiff
         repeated ContractStoredValue values = 4;
     }
 
+    message ContractAddrToClassHash {
+        Address contract_addr = 1;
+        Hash    class_hash    = 2;
+    }
+
     uint32   domain                      = 1;  // volition state domain
     repeated ContractDiff contract_diffs = 2;
+    repeated ContractAddrToClassHash replaced_classes   = 3;
+    repeated ContractAddrToClassHash deployed_contracts = 4;
 }
 
 message EntryPoint {


### PR DESCRIPTION
To verify the state diff commitment we need to have access to all the fields present in the `StateDiff` returned by the feeder gateway. Therefore, we need to have `deployed_contract` and `replaced_classes` in the `StateDiff` messages.

The reason for not including the `DeclaredV0Classes` and `DeclaredV1Classes` is because these can be derived from the `Classes` message, which all Cairo0 and Cairo1 classes can be mapped to `DeclaredV0Classes` and `DeclaredV1Classes`, respectively.