### PR TITLE
Add class_hash to the Cairo0 message

### DIFF
--- a/p2p/proto/state.proto
+++ b/p2p/proto/state.proto
@@ -33,6 +33,7 @@ message Cairo0Class {
     repeated EntryPoint l1_handlers = 3;
     repeated EntryPoint constructors = 4;
     bytes program = 5;
+    Hash  class_hash    = 6;
 }
 
 message SierraEntryPoint {


### PR DESCRIPTION
As Cairo0 is deprecated, clients should not be expected to generate its class hash.