### PR TITLE
Add `CurrentBlockHeaderRequest{}`

### DIFF
--- a/p2p/proto/block.proto
+++ b/p2p/proto/block.proto
@@ -45,6 +45,8 @@ message NewBlock {
     }
 }
 
+// Requests a peer's CurrentBlockHeader
+message CurrentBlockHeaderRequest {}
 
 // result is (BlockHeader, Signature?)* in order of creation (incr/dec)
 message BlockHeadersRequest {


### PR DESCRIPTION
The response to `CurrentBlockHeaderRequest{}` is the peer's local current header. This can be used to get a rough idea of what the latest block is as viewed by other peers on the network. The header can be compared with a subset of peers to determine an efficient way of pulling blocks from the network while syncing.

Initially, we modified the iteration message to include a `latest` option, however, since the iteration message is shared by multiple requests it didn't make sense for each of the messages to have access to it.