### PR TITLE
Prepend chain id in discovery protocol

### DIFF
--- a/p2p/proto/protocols.md
+++ b/p2p/proto/protocols.md
@@ -23,7 +23,7 @@ negotiation, and the protobuf messages related to the protocol.
 | Classes | /starknet/classes/0.1.0-rc.0 | [ClassesRequest](./class.proto) | [ClassesResponse](./class.proto) |
 | Transactions | /starknet/transactions/0.1.0-rc.0 | [TransactionsRequest](./transaction.proto) | [TransactionsResponse](./transaction.proto) |
 | Events | /starknet/events/0.1.0-rc.0 | [EventsRequest](./event.proto) | [EventsResponse](./event.proto) |
-| Kademlia (for discovery) | /starknet/kad/<chain_id>/1.0.0 |
+| Kademlia (for discovery) | /starknet/<chain_id>/kad/1.0.0 |
 
 In addition, nodes should also support the `Identify` protocol, who's name for negotiation is
 `/ipfs/id/1.0.0`


### PR DESCRIPTION
In go-libp2p, the `/kad` string is prepended with the defined protocol prefix (i.e. `<protocol>/kad/1.0.0`). It's not possible to have it appended (i.e. `/starknet/kad/<chain_id>/1.0.0`), as shown [here](https://github.com/libp2p/go-libp2p-kad-dht/blob/master/dht.go#L284). Hence we should follow the format given by libp2p.