### PR TITLE
feat: add fields associated with starknet 0.13.2 upgrade

### DIFF
--- a/p2p/proto/receipt.proto
+++ b/p2p/proto/receipt.proto
@@ -27,6 +27,9 @@ message Receipt {
       uint32 poseidon = 6;
       uint32 keccak = 7;
       uint32 output = 8;
+      uint32 add_mod = 9;
+      uint32 mul_mod = 10;
+      uint32 range_check96 = 11;
     }
 
     BuiltinCounter builtins = 1;
@@ -34,6 +37,7 @@ message Receipt {
     uint32 memory_holes = 3;
     Felt252 l1_gas = 4;
     Felt252 l1_data_gas = 5;
+    Felt252 total_l1_gas = 6;
   }
 
   message Common {


### PR DESCRIPTION
`total_l1_gas` and `total_l1_data_gas` are required for correct receipt commitment computation.