### PR TITLE
Add signatures to `ProposalPart` and `Vote` and remove `ConsensusMessage`

### DIFF
--- a/p2p/proto/consensus.proto
+++ b/p2p/proto/consensus.proto
@@ -49,7 +49,7 @@ message ProposalFin {
 // `R` proposal P is locked. Then in a later round the timestamp in P has gone stale. Therefore the
 // lower bound should be "greater than the previous timestamp". Upper bounds don't suffer from this
 // problem.
-message Proposal {
+message ProposalPart {
     oneof messages {
         ProposalInit init         = 1;
         ProposalFin  fin          = 2;

--- a/p2p/proto/consensus.proto
+++ b/p2p/proto/consensus.proto
@@ -23,6 +23,8 @@ message Vote {
     optional Hash      block_hash   = 6;
     // Identifies the voter.
     Address            voter        = 7;
+    // Signature by the voter.
+    ConsensusSignature signature    = 8;
 }
 
 message ProposalInit {
@@ -60,5 +62,7 @@ message ProposalPart {
         Transactions transactions = 3;
         BlockProof   proof        = 4;
     }
+    // Signature by the proposer.
+    ConsensusSignature signature    = 5;
 }
 

--- a/p2p/proto/consensus.proto
+++ b/p2p/proto/consensus.proto
@@ -62,11 +62,3 @@ message Proposal {
     }
 }
 
-message ConsensusMessage {
-    oneof messages {
-        Vote     vote     = 1;
-        Proposal proposal = 2;
-    }
-    // Signature by the initial sender (e.g. proposer, voter) of the message.
-    ConsensusSignature signature    = 3;
-}


### PR DESCRIPTION
As discussed with @matan-starkware off band, we can remove the `ConsensusMessage` proto as votes and proposal parts will transmitted over different GossipSub topics and can therefore each have their own message types instead of an enumeration.

We therefore need to add a `signature` field to the `Vote` and `ProposalPart` (previously `Proposal`) protos.

/cc @matan-starkware @ShahakShama @ittayd 