### PR TITLE
L1 handler message hash values are 256 bit

### DIFF
--- a/p2p/proto/common.proto
+++ b/p2p/proto/common.proto
@@ -4,7 +4,14 @@ message Felt252 {
     bytes elements = 1;
 }
 
+// A hash value representable as a Felt252
 message Hash {
+    bytes elements = 1;
+}
+
+// A 256 bit hash value (like Keccak256)
+message Hash256 {
+    // Required to be 32 bytes long
     bytes elements = 1;
 }
 

--- a/p2p/proto/receipt.proto
+++ b/p2p/proto/receipt.proto
@@ -55,7 +55,7 @@ message Receipt {
 
   message L1Handler {
     Common common = 1;
-    Hash msg_hash = 2;
+    Hash256 msg_hash = 2;
   }
 
   message Declare {


### PR DESCRIPTION
This change introduces a new `Hash256` message type to describe fields that are hash values but cannot be represented as a Felt252.

For example, message hashes for L1 messages are defined as Keccak256 hashes: https://docs.starknet.io/architecture-and-concepts/network-architecture/messaging-mechanism/#hashing_l1-l2

All other uses of the `Hash` message are _indeed_ hash function output either from the Starknet Poseidon or Pedersen hashes, so `Hash` should be parsed as a Felt252 value.