### PR TITLE
chore: fix typo

### DIFF
--- a/p2p/proto/snapshot.proto
+++ b/p2p/proto/snapshot.proto
@@ -28,7 +28,7 @@ message PatriciaRangeProof {
     repeated PatriciaNode nodes = 1;
 }
 
-// leafs of the contract state tree
+// leaves of the contract state tree
 message ContractState {
     Address address = 1;  // the key
     Hash class = 2;


### PR DESCRIPTION
In [Pathfinder](https://github.com/eqlabs/pathfinder) we have automatic sync of our proto schemas from this repository.

This typo always causes a failure in our CI.

Would be great if we could fix this.